### PR TITLE
Add extra personalization with more complete cookie consent and better banner styles

### DIFF
--- a/src/analytics/ga4.ts
+++ b/src/analytics/ga4.ts
@@ -17,15 +17,20 @@ import {
     loadGoogleAnalyticsScript,
 } from "@analytics/ga-lib.ts";
 
+// https://support.google.com/tagmanager/answer/10718549
 export interface GoogleAnalyticsConsent {
     analyticsStorage: GoogleAnalyticsConsentPermission;
     adUserData: GoogleAnalyticsConsentPermission;
     adPersonalization: GoogleAnalyticsConsentPermission;
     adStorage: GoogleAnalyticsConsentPermission;
+    functionalityStorage: GoogleAnalyticsConsentPermission;
+    personalizationStorage: GoogleAnalyticsConsentPermission;
+    securityStorage: GoogleAnalyticsConsentPermission;
 }
 
 export function newGoogleAnalyticsConsent(
     {
+        functional,
         analytics,
         targeting,
     }: CookieConsent,
@@ -35,6 +40,9 @@ export function newGoogleAnalyticsConsent(
         adUserData: booleanToPermission(targeting),
         adPersonalization: booleanToPermission(targeting),
         adStorage: booleanToPermission(targeting),
+        functionalityStorage: booleanToPermission(functional),
+        personalizationStorage: booleanToPermission(targeting),
+        securityStorage: booleanToPermission(functional),
     };
 }
 
@@ -83,6 +91,9 @@ export function initializeGoogleAnalytics(
             "ad_personalization": consent?.adPersonalization ?? "denied",
             "ad_storage": consent?.adStorage ?? "denied",
             "analytics_storage": consent?.analyticsStorage ?? "denied",
+            "functionality_storage": consent?.functionalityStorage ?? "denied",
+            "personalization_storage": consent?.personalizationStorage ?? "denied",
+            "security_storage": consent?.securityStorage ?? "denied",
         },
     );
 
@@ -102,6 +113,9 @@ export function updateGoogleAnalyticsConsent(
         adUserData,
         adPersonalization,
         adStorage,
+        functionalityStorage,
+        personalizationStorage,
+        securityStorage,
     }: GoogleAnalyticsConsent,
 ) {
     gtag(
@@ -112,6 +126,9 @@ export function updateGoogleAnalyticsConsent(
             "ad_personalization": adPersonalization,
             "ad_storage": adStorage,
             "analytics_storage": analyticsStorage,
+            "functionality_storage": functionalityStorage,
+            "personalization_storage": personalizationStorage,
+            "security_storage": securityStorage,
         },
     );
 }

--- a/src/analytics/ga4.ts
+++ b/src/analytics/ga4.ts
@@ -19,11 +19,22 @@ import {
 
 export interface GoogleAnalyticsConsent {
     analyticsStorage: GoogleAnalyticsConsentPermission;
+    adUserData: GoogleAnalyticsConsentPermission;
+    adPersonalization: GoogleAnalyticsConsentPermission;
+    adStorage: GoogleAnalyticsConsentPermission;
 }
 
-export function newGoogleAnalyticsConsent({ analytics }: CookieConsent): GoogleAnalyticsConsent {
+export function newGoogleAnalyticsConsent(
+    {
+        analytics,
+        targeting,
+    }: CookieConsent,
+): GoogleAnalyticsConsent {
     return {
         analyticsStorage: booleanToPermission(analytics),
+        adUserData: booleanToPermission(targeting),
+        adPersonalization: booleanToPermission(targeting),
+        adStorage: booleanToPermission(targeting),
     };
 }
 
@@ -68,9 +79,9 @@ export function initializeGoogleAnalytics(
         "consent",
         "default",
         {
-            "ad_user_data": "denied",
-            "ad_personalization": "denied",
-            "ad_storage": "denied",
+            "ad_user_data": consent?.adUserData ?? "denied",
+            "ad_personalization": consent?.adPersonalization ?? "denied",
+            "ad_storage": consent?.adStorage ?? "denied",
             "analytics_storage": consent?.analyticsStorage ?? "denied",
         },
     );
@@ -86,15 +97,20 @@ export function initializeGoogleAnalytics(
  * example, when the cookie banner is updated.
  */
 export function updateGoogleAnalyticsConsent(
-    { analyticsStorage }: GoogleAnalyticsConsent,
+    {
+        analyticsStorage,
+        adUserData,
+        adPersonalization,
+        adStorage,
+    }: GoogleAnalyticsConsent,
 ) {
     gtag(
         "consent",
         "update",
         {
-            "ad_user_data": "denied",
-            "ad_personalization": "denied",
-            "ad_storage": "denied",
+            "ad_user_data": adUserData,
+            "ad_personalization": adPersonalization,
+            "ad_storage": adStorage,
             "analytics_storage": analyticsStorage,
         },
     );

--- a/src/app/legal/CookieBannerConsent.tsx
+++ b/src/app/legal/CookieBannerConsent.tsx
@@ -15,10 +15,18 @@ import {
 
 const cookiePolicyLink = "/legal#cookies";
 
-function newCookieConsent({ analytics }: CookiePref): CookieConsent {
+function newCookieConsent(
+    {
+        functional,
+        analytics,
+        targeting,
+    }: CookiePref,
+): CookieConsent {
     return {
         necessary: true,
+        functional: functional ?? false,
         analytics: analytics ?? false,
+        targeting: targeting ?? false,
     };
 }
 
@@ -41,9 +49,9 @@ function CookieBannerConsent() {
     };
 
     useEffect(() => {
-        const { analytics } = loadCookieConsent(cookies);
+        const { functional, analytics, targeting } = loadCookieConsent(cookies);
 
-        setPref({ analytics });
+        setPref({ functional, analytics, targeting });
 
         if (!cookies[consentCookieName]) {
             dispatch(show());

--- a/src/app/legal/CookieBannerConsent.tsx
+++ b/src/app/legal/CookieBannerConsent.tsx
@@ -40,6 +40,8 @@ function CookieBannerConsent() {
 
     const [ pref, setPref ] = useState(defPref);
 
+    const [ domainName, setDomainName ] = useState("");
+
     const save = (pref: CookiePref) => {
         const consent = newCookieConsent(pref);
         const { cookieName, consentSer, options } = applyConsent(consent);
@@ -58,8 +60,11 @@ function CookieBannerConsent() {
         }
     }, [ cookies, dispatch ]);
 
+    useEffect(() => setDomainName(import.meta.env.VITE_DOMAIN_NAME ?? ""), []);
+
     return <>
         <CookieBanner
+            domainName={ domainName }
             cookiePolicyLink={ cookiePolicyLink }
             show={ showCookieBanner }
             initialForm={ pref }

--- a/src/app/legal/Legal.tsx
+++ b/src/app/legal/Legal.tsx
@@ -93,6 +93,19 @@ function CookieTypes() {
                 used properly without these strictly necessary cookies.
             </p>
             <p>
+                <strong>Functional Cookies:</strong>
+                &nbsp;
+                These enhance the website or web app performance as certain
+                functions may not be available without them. They allow users to
+                remember their preferences and settings, provide a personalized
+                user experience, are anonymous, be first-party or set by
+                third-party service providers, and do not track browsing
+                activity across other websites. For example, cookies that
+                remember user location, chosen language, or other settings, a
+                live web chat platform, and optional security parameters like a
+                single sign-on (SSO).
+            </p>
+            <p>
                 <strong>Analytical Cookies:</strong>
                 &nbsp;
                 These cookies collect data on how users interact with the
@@ -100,6 +113,18 @@ function CookieTypes() {
                 rates, and traffic sources. They cannot be used to directly
                 identify a certain visitor. They help website owners understand
                 and improve site performance.
+            </p>
+            <p>
+                <strong>Targeting Cookies:</strong>
+                &nbsp;
+                These are used to identify visitors between different websites
+                and may be used by companies to build a profile of visitor
+                interests or show relevant ads on other websites, and are
+                usually third-party. They are used on a limited basis, and we do
+                not use them to serve third-party ads on our websites or web
+                apps. For example, cookies installed by YouTube in videos
+                embedded into our site to track their views and user
+                preferences.
             </p>
         </section>
     </>;

--- a/src/persistence/cookie-consent.ts
+++ b/src/persistence/cookie-consent.ts
@@ -7,10 +7,17 @@ export const consentCookieName = "cookie-consent";
 
 export interface CookieConsent {
     necessary: boolean;
+    functional: boolean;
     analytics: boolean;
+    targeting: boolean;
 }
 
-export const defConsent: CookieConsent = { necessary: true, analytics: false };
+export const defConsent: CookieConsent = {
+    necessary: true,
+    functional: false,
+    analytics: false,
+    targeting: false,
+};
 
 export interface AppliedConsent {
     cookieName: "cookie-consent";
@@ -24,11 +31,13 @@ export function loadCookieConsent(cookies: Record<string, Record<string, string>
     }
 
     const consentCookie = cookies[consentCookieName];
-    const getBoolean = (key: string) => consentCookie[key].toString() === "true";
+    const getBoolean = (key: string) => consentCookie[key]?.toString() === "true";
 
     return {
         necessary: true,
+        functional: getBoolean("functional"),
         analytics: getBoolean("analytics"),
+        targeting: getBoolean("targeting"),
     };
 }
 

--- a/src/ui/legal/CookieBanner.css
+++ b/src/ui/legal/CookieBanner.css
@@ -50,6 +50,20 @@
     font-family: "Poppins Medium", sans-serif;
 }
 
+#cookieBanner .check-col {
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+}
+
+#cookieBanner .check-col .form-check {
+    min-height: 1.25rem;
+}
+
+#cookieBanner .check-col .form-check:last-child {
+    margin-bottom: 0;
+}
+
 @media (min-width: 600px) {
     #cookieBanner {
         font-size: 0.875rem;

--- a/src/ui/legal/CookieBanner.css
+++ b/src/ui/legal/CookieBanner.css
@@ -28,6 +28,7 @@
 #cookieBanner .selection {
     display: flex;
     flex-direction: row;
+    margin-bottom: 0.75rem;
 }
 
 #cookieBanner button {

--- a/src/ui/legal/CookieBanner.css
+++ b/src/ui/legal/CookieBanner.css
@@ -25,15 +25,8 @@
     transform: translateY(0);
 }
 
-#cookieBanner .selection {
-    display: flex;
-    flex-direction: row;
-    margin-bottom: 0.75rem;
-}
-
 #cookieBanner button {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    padding: 0.5rem 0.5rem;
     font-size: 0.75rem;
 }
 

--- a/src/ui/legal/CookieBanner.css
+++ b/src/ui/legal/CookieBanner.css
@@ -25,6 +25,11 @@
     transform: translateY(0);
 }
 
+#cookieBanner .selection {
+    display: flex;
+    flex-direction: row;
+}
+
 #cookieBanner button {
     font-size: 0.75rem;
 }

--- a/src/ui/legal/CookieBanner.css
+++ b/src/ui/legal/CookieBanner.css
@@ -5,7 +5,6 @@
     position: fixed;
     width: 100%;
     padding: var(--content-padding);
-    right: 0;
     bottom: 0;
     background-color: #1c1c1c;
     z-index: 3;
@@ -76,6 +75,13 @@
     }
 }
 
+@media screen and (min-width: 800px) and (min-height: 600px) {
+    #cookieBanner {
+        width: 70%;
+        right: 15%;
+    }
+}
+
 @media (min-width: 1280px) {
     #cookieBanner button {
         padding-left: 0.5rem;
@@ -85,6 +91,7 @@
 
     #cookieBanner {
         width: 30%;
+        right: 0;
     }
 }
 

--- a/src/ui/legal/CookieBanner.css
+++ b/src/ui/legal/CookieBanner.css
@@ -17,6 +17,7 @@
     transition: opacity 0.4s, transform 0.4s;
     opacity: 0;
     transform: translateY(100%);
+    user-select: none;
 }
 
 #cookieBanner.show {

--- a/src/ui/legal/CookieBanner.css
+++ b/src/ui/legal/CookieBanner.css
@@ -32,6 +32,8 @@
 }
 
 #cookieBanner button {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
     font-size: 0.75rem;
 }
 
@@ -61,12 +63,28 @@
     }
 
     #cookieBanner button {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
         font-size: 1rem;
     }
 }
 
 @media (min-width: 1280px) {
+    #cookieBanner button {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+        font-size: 0.75rem;
+    }
+
     #cookieBanner {
         width: 30%;
+    }
+}
+
+@media (min-width: 1600px) {
+    #cookieBanner button {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+        font-size: 1rem;
     }
 }

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -120,8 +120,8 @@ function CookieAction({ onSave, form }: CookieActionProps) {
             <Form>
                 <Form.Check
                     id="cookieNecessaryCheck"
-                    label="Strictly necessary"
-                    title="Strictly necessary cookies"
+                    label="Essential"
+                    title="Essential cookies"
                     type="checkbox"
                     inline
                     checked

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -99,6 +99,8 @@ function CookieAction({ onSave, form }: CookieActionProps) {
     const [ analytics, setAnalytics ] = useState<boolean | undefined>();
     const [ targeting, setTargeting ] = useState<boolean | undefined>();
 
+    const essentialOnly = () => { onSave(defPref); };
+
     const acceptAll = () => { onSave(acceptAllPref); };
 
     const saveSelection = () => {
@@ -148,10 +150,28 @@ function CookieAction({ onSave, form }: CookieActionProps) {
                     />
                 </div>
 
-                <div className="mt-2 d-flex justify-content-between">
+                <div className="d-grid gap-2 gap-md-3">
                     <Button
                         variant="primary"
-                        className="flex-fill"
+                        style={ {
+                            gridRowStart: 1,
+                            gridRowEnd: 1,
+                            gridColumnStart: 1,
+                            gridColumnEnd: 1,
+                        } }
+                        onClick={ essentialOnly }
+                    >
+                        Essential Only
+                    </Button>
+
+                    <Button
+                        variant="primary"
+                        style={ {
+                            gridRowStart: 2,
+                            gridRowEnd: 2,
+                            gridColumnStart: 1,
+                            gridColumnEnd: 1,
+                        } }
                         onClick={ acceptAll }
                     >
                         Accept All
@@ -159,13 +179,26 @@ function CookieAction({ onSave, form }: CookieActionProps) {
 
                     <Button
                         variant="outline-primary"
-                        className="flex-fill mx-2 mx-md-4"
+                        style={ {
+                            gridRowStart: 2,
+                            gridRowEnd: 2,
+                            gridColumnStart: 2,
+                            gridColumnEnd: 2,
+                        } }
                         onClick={ saveSelection }
                     >
                         Save Selection
                     </Button>
 
-                    <Button variant="outline-primary" className="flex-fill">
+                    <Button
+                        variant="outline-primary"
+                        style={ {
+                            gridRowStart: 2,
+                            gridRowEnd: 2,
+                            gridColumnStart: 3,
+                            gridColumnEnd: 3,
+                        } }
+                    >
                         Customize
                     </Button>
                 </div>

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -59,12 +59,6 @@ function CookieContent({ domainName, cookiePolicyLink }: CookieContentProps) {
                 will be valid across all our subdomains. Learn
                 more in our <a href={ cookiePolicyLink }>Cookies Policy</a>.
             </p>
-
-            <p>
-                You can always set your consent by clicking
-                the &quot;Cookie Preference&quot; button at the page
-                footer.
-            </p>
         </div>
     </>;
 }

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -84,7 +84,6 @@ function CheckAction({ name, onChange, state }: CheckActionProps) {
             type="checkbox"
             onChange={ e => onChange(e.target.checked) }
             checked={ state }
-            inline
         />
     </>;
 }
@@ -121,23 +120,8 @@ function CookieAction({ onSave, form }: CookieActionProps) {
         <div className="action">
             <Form>
                 <div className="d-grid gap-3 gap-md-3">
-                    <Form.Check
-                        id="cookieNecessaryCheck"
-                        label="Essential"
-                        title="Essential cookies"
-                        type="checkbox"
-                        style={ {
-                            gridRowStart: 1,
-                            gridRowEnd: 1,
-                            gridColumnStart: 1,
-                            gridColumnEnd: 1,
-                        } }
-                        inline
-                        checked
-                        disabled
-                    />
-
                     <div
+                        className="d-flex"
                         style={ {
                             gridRowStart: 1,
                             gridRowEnd: "span 2",
@@ -145,23 +129,34 @@ function CookieAction({ onSave, form }: CookieActionProps) {
                             gridColumnEnd: "span 2",
                         } }
                     >
-                        <CheckAction
-                            name="functional"
-                            state={ functional }
-                            onChange={ setFunctional }
-                        />
+                        <div className="check-col me-3">
+                            <Form.Check
+                                id="cookieNecessaryCheck"
+                                label="Essential"
+                                title="Essential cookies"
+                                type="checkbox"
+                                checked
+                                disabled
+                            />
+                            <CheckAction
+                                name="functional"
+                                state={ functional }
+                                onChange={ setFunctional }
+                            />
+                        </div>
+                        <div className="check-col">
+                            <CheckAction
+                                name="analytics"
+                                state={ analytics }
+                                onChange={ setAnalytics }
+                            />
+                            <CheckAction
+                                name="targeting"
+                                state={ targeting }
+                                onChange={ setTargeting }
+                            />
+                        </div>
 
-                        <CheckAction
-                            name="analytics"
-                            state={ analytics }
-                            onChange={ setAnalytics }
-                        />
-
-                        <CheckAction
-                            name="targeting"
-                            state={ targeting }
-                            onChange={ setTargeting }
-                        />
                     </div>
 
                     <Button

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -120,42 +120,55 @@ function CookieAction({ onSave, form }: CookieActionProps) {
     return <>
         <div className="action">
             <Form>
-                <Form.Check
-                    id="cookieNecessaryCheck"
-                    label="Essential"
-                    title="Essential cookies"
-                    type="checkbox"
-                    inline
-                    checked
-                    disabled
-                />
-
-                <div className="selection">
-                    <CheckAction
-                        name="functional"
-                        state={ functional }
-                        onChange={ setFunctional }
-                    />
-
-                    <CheckAction
-                        name="analytics"
-                        state={ analytics }
-                        onChange={ setAnalytics }
-                    />
-
-                    <CheckAction
-                        name="targeting"
-                        state={ targeting }
-                        onChange={ setTargeting }
-                    />
-                </div>
-
-                <div className="d-grid gap-2 gap-md-3">
-                    <Button
-                        variant="primary"
+                <div className="d-grid gap-3 gap-md-3">
+                    <Form.Check
+                        id="cookieNecessaryCheck"
+                        label="Essential"
+                        title="Essential cookies"
+                        type="checkbox"
                         style={ {
                             gridRowStart: 1,
                             gridRowEnd: 1,
+                            gridColumnStart: 1,
+                            gridColumnEnd: 1,
+                        } }
+                        inline
+                        checked
+                        disabled
+                    />
+
+                    <div
+                        style={ {
+                            gridRowStart: 1,
+                            gridRowEnd: "span 2",
+                            gridColumnStart: 2,
+                            gridColumnEnd: "span 2",
+                        } }
+                    >
+                        <CheckAction
+                            name="functional"
+                            state={ functional }
+                            onChange={ setFunctional }
+                        />
+
+                        <CheckAction
+                            name="analytics"
+                            state={ analytics }
+                            onChange={ setAnalytics }
+                        />
+
+                        <CheckAction
+                            name="targeting"
+                            state={ targeting }
+                            onChange={ setTargeting }
+                        />
+                    </div>
+
+                    <Button
+                        variant="primary"
+                        style={ {
+                            gridRowStart: 2,
+                            gridRowEnd: 2,
                             gridColumnStart: 1,
                             gridColumnEnd: 1,
                         } }
@@ -167,8 +180,8 @@ function CookieAction({ onSave, form }: CookieActionProps) {
                     <Button
                         variant="primary"
                         style={ {
-                            gridRowStart: 2,
-                            gridRowEnd: 2,
+                            gridRowStart: 3,
+                            gridRowEnd: 3,
                             gridColumnStart: 1,
                             gridColumnEnd: 1,
                         } }
@@ -180,8 +193,8 @@ function CookieAction({ onSave, form }: CookieActionProps) {
                     <Button
                         variant="outline-primary"
                         style={ {
-                            gridRowStart: 2,
-                            gridRowEnd: 2,
+                            gridRowStart: 3,
+                            gridRowEnd: 3,
                             gridColumnStart: 2,
                             gridColumnEnd: 2,
                         } }
@@ -193,8 +206,8 @@ function CookieAction({ onSave, form }: CookieActionProps) {
                     <Button
                         variant="outline-primary"
                         style={ {
-                            gridRowStart: 2,
-                            gridRowEnd: 2,
+                            gridRowStart: 3,
+                            gridRowEnd: 3,
                             gridColumnStart: 3,
                             gridColumnEnd: 3,
                         } }

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -33,10 +33,11 @@ export const acceptAllPref: CookiePref = {
 };
 
 interface CookieContentProps {
+    domainName: string;
     cookiePolicyLink: string;
 }
 
-function CookieContent({ cookiePolicyLink }: CookieContentProps) {
+function CookieContent({ domainName, cookiePolicyLink }: CookieContentProps) {
     return <>
         <div className="content">
             <h5>
@@ -54,13 +55,12 @@ function CookieContent({ cookiePolicyLink }: CookieContentProps) {
 
             <p>
                 We use cookies to improve user experience. Choose what
-                cookies you allow us to use. Learn
+                cookies you allow <b>{ domainName }</b> to use. Your consent
+                will be valid across all our subdomains. Learn
                 more in our <a href={ cookiePolicyLink }>Cookies Policy</a>.
             </p>
 
             <p>
-                Your consent will be valid across all our subdomains.
-
                 You can always set your consent by clicking
                 the &quot;Cookie Preference&quot; button at the page
                 footer.
@@ -237,6 +237,7 @@ function CloseIcon({ onClose }: CloseIconProps) {
 }
 
 interface CookieBannerProps {
+    domainName: string;
     cookiePolicyLink: string;
     initialForm: CookiePref;
     show: boolean;
@@ -255,6 +256,7 @@ function usePrevious<T>(value: T) {
 
 function CookieBanner(
     {
+        domainName,
         cookiePolicyLink,
         initialForm,
         show,
@@ -297,7 +299,10 @@ function CookieBanner(
             className={ className }
             onTransitionEnd={ onTransitionEnd }
         >
-            <CookieContent cookiePolicyLink={ cookiePolicyLink } />
+            <CookieContent
+                domainName={ domainName }
+                cookiePolicyLink={ cookiePolicyLink }
+            />
 
             <CookieAction onSave={ onSave } form={ form } />
 

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -15,12 +15,22 @@ import React, {
 } from "react";
 
 export interface CookiePref {
+    functional?: boolean;
     analytics?: boolean;
+    targeting?: boolean;
 }
 
-export const defPref: CookiePref = { analytics: false };
+export const defPref: CookiePref = {
+    functional: false,
+    analytics: false,
+    targeting: false,
+};
 
-export const acceptAllPref: CookiePref = { analytics: true };
+export const acceptAllPref: CookiePref = {
+    functional: true,
+    analytics: true,
+    targeting: true,
+};
 
 interface CookieContentProps {
     cookiePolicyLink: string;
@@ -85,14 +95,24 @@ interface CookieActionProps {
 }
 
 function CookieAction({ onSave, form }: CookieActionProps) {
+    const [ functional, setFunctional ] = useState<boolean | undefined>();
     const [ analytics, setAnalytics ] = useState<boolean | undefined>();
+    const [ targeting, setTargeting ] = useState<boolean | undefined>();
 
     const acceptAll = () => { onSave(acceptAllPref); };
 
-    const saveSelection = () => { onSave({ analytics }); };
+    const saveSelection = () => {
+        onSave({
+            functional,
+            analytics,
+            targeting,
+        });
+    };
 
     useEffect(() => {
+        setFunctional(form.functional);
         setAnalytics(form.analytics);
+        setTargeting(form.targeting);
     }, [ form ]);
 
     return <>
@@ -109,9 +129,21 @@ function CookieAction({ onSave, form }: CookieActionProps) {
                 />
 
                 <CheckAction
+                    name="functional"
+                    state={ functional }
+                    onChange={ setFunctional }
+                />
+
+                <CheckAction
                     name="analytics"
                     state={ analytics }
                     onChange={ setAnalytics }
+                />
+
+                <CheckAction
+                    name="targeting"
+                    state={ targeting }
+                    onChange={ setTargeting }
                 />
 
                 <div className="mt-2 d-flex justify-content-between">

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -117,101 +117,99 @@ function CookieAction({ onSave, form }: CookieActionProps) {
     }, [ form ]);
 
     return <>
-        <div className="action">
-            <Form>
-                <div className="d-grid gap-3 gap-md-3">
-                    <div
-                        className="d-flex"
-                        style={ {
-                            gridRowStart: 1,
-                            gridRowEnd: "span 2",
-                            gridColumnStart: 2,
-                            gridColumnEnd: "span 2",
-                        } }
-                    >
-                        <div className="check-col me-3">
-                            <Form.Check
-                                id="cookieNecessaryCheck"
-                                label="Essential"
-                                title="Essential cookies"
-                                type="checkbox"
-                                checked
-                                disabled
-                            />
-                            <CheckAction
-                                name="functional"
-                                state={ functional }
-                                onChange={ setFunctional }
-                            />
-                        </div>
-                        <div className="check-col">
-                            <CheckAction
-                                name="analytics"
-                                state={ analytics }
-                                onChange={ setAnalytics }
-                            />
-                            <CheckAction
-                                name="targeting"
-                                state={ targeting }
-                                onChange={ setTargeting }
-                            />
-                        </div>
-
+        <Form>
+            <div className="d-grid gap-3 gap-md-3">
+                <div
+                    className="d-flex"
+                    style={ {
+                        gridRowStart: 1,
+                        gridRowEnd: "span 2",
+                        gridColumnStart: 2,
+                        gridColumnEnd: "span 2",
+                    } }
+                >
+                    <div className="check-col me-3">
+                        <Form.Check
+                            id="cookieNecessaryCheck"
+                            label="Essential"
+                            title="Essential cookies"
+                            type="checkbox"
+                            checked
+                            disabled
+                        />
+                        <CheckAction
+                            name="functional"
+                            state={ functional }
+                            onChange={ setFunctional }
+                        />
+                    </div>
+                    <div className="check-col">
+                        <CheckAction
+                            name="analytics"
+                            state={ analytics }
+                            onChange={ setAnalytics }
+                        />
+                        <CheckAction
+                            name="targeting"
+                            state={ targeting }
+                            onChange={ setTargeting }
+                        />
                     </div>
 
-                    <Button
-                        variant="primary"
-                        style={ {
-                            gridRowStart: 2,
-                            gridRowEnd: 2,
-                            gridColumnStart: 1,
-                            gridColumnEnd: 1,
-                        } }
-                        onClick={ essentialOnly }
-                    >
-                        Essential Only
-                    </Button>
-
-                    <Button
-                        variant="primary"
-                        style={ {
-                            gridRowStart: 3,
-                            gridRowEnd: 3,
-                            gridColumnStart: 1,
-                            gridColumnEnd: 1,
-                        } }
-                        onClick={ acceptAll }
-                    >
-                        Accept All
-                    </Button>
-
-                    <Button
-                        variant="outline-primary"
-                        style={ {
-                            gridRowStart: 3,
-                            gridRowEnd: 3,
-                            gridColumnStart: 2,
-                            gridColumnEnd: 2,
-                        } }
-                        onClick={ saveSelection }
-                    >
-                        Save Selection
-                    </Button>
-
-                    <Button
-                        variant="outline-primary"
-                        style={ {
-                            gridRowStart: 3,
-                            gridRowEnd: 3,
-                            gridColumnStart: 3,
-                            gridColumnEnd: 3,
-                        } }
-                    >
-                        Customize
-                    </Button>
                 </div>
-            </Form>
-        </div>
+
+                <Button
+                    variant="primary"
+                    style={ {
+                        gridRowStart: 2,
+                        gridRowEnd: 2,
+                        gridColumnStart: 1,
+                        gridColumnEnd: 1,
+                    } }
+                    onClick={ essentialOnly }
+                >
+                    Essential Only
+                </Button>
+
+                <Button
+                    variant="primary"
+                    style={ {
+                        gridRowStart: 3,
+                        gridRowEnd: 3,
+                        gridColumnStart: 1,
+                        gridColumnEnd: 1,
+                    } }
+                    onClick={ acceptAll }
+                >
+                    Accept All
+                </Button>
+
+                <Button
+                    variant="outline-primary"
+                    style={ {
+                        gridRowStart: 3,
+                        gridRowEnd: 3,
+                        gridColumnStart: 2,
+                        gridColumnEnd: 2,
+                    } }
+                    onClick={ saveSelection }
+                >
+                    Save Selection
+                </Button>
+
+                <Button
+                    variant="outline-primary"
+                    style={ {
+                        gridRowStart: 3,
+                        gridRowEnd: 3,
+                        gridColumnStart: 3,
+                        gridColumnEnd: 3,
+                    } }
+                >
+                    Customize
+                </Button>
+            </div>
+        </Form>
     </>;
 }
 

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -128,23 +128,25 @@ function CookieAction({ onSave, form }: CookieActionProps) {
                     disabled
                 />
 
-                <CheckAction
-                    name="functional"
-                    state={ functional }
-                    onChange={ setFunctional }
-                />
+                <div className="selection">
+                    <CheckAction
+                        name="functional"
+                        state={ functional }
+                        onChange={ setFunctional }
+                    />
 
-                <CheckAction
-                    name="analytics"
-                    state={ analytics }
-                    onChange={ setAnalytics }
-                />
+                    <CheckAction
+                        name="analytics"
+                        state={ analytics }
+                        onChange={ setAnalytics }
+                    />
 
-                <CheckAction
-                    name="targeting"
-                    state={ targeting }
-                    onChange={ setTargeting }
-                />
+                    <CheckAction
+                        name="targeting"
+                        state={ targeting }
+                        onChange={ setTargeting }
+                    />
+                </div>
 
                 <div className="mt-2 d-flex justify-content-between">
                     <Button


### PR DESCRIPTION
It adds the other common categories of cookies: functional, and targeting.

It sets the other Google consent parameters from the Google documentation. They may not be required, but the system will set them accordingly.

It allows quality personalization by showing the underlying domain name requesting consent in the banner.

Personalization is even more complying now by enabling the "Essential Only" CTA button in the cookie banner, besides the existing "Accept All" CTA button.

It improves some styles for better readability in the cookie banner.
