### PR TITLE
Rename field from analytics to analytical (CookieConsent)

### DIFF
--- a/src/analytics/ga4.ts
+++ b/src/analytics/ga4.ts
@@ -31,12 +31,12 @@ export interface GoogleAnalyticsConsent {
 export function newGoogleAnalyticsConsent(
     {
         functional,
-        analytics,
+        analytical,
         targeting,
     }: CookieConsent,
 ): GoogleAnalyticsConsent {
     return {
-        analyticsStorage: booleanToPermission(analytics),
+        analyticsStorage: booleanToPermission(analytical),
         adUserData: booleanToPermission(targeting),
         adPersonalization: booleanToPermission(targeting),
         adStorage: booleanToPermission(targeting),

--- a/src/app/legal/cookies/AppCookieBanner.tsx
+++ b/src/app/legal/cookies/AppCookieBanner.tsx
@@ -25,14 +25,14 @@ const cookiePolicyLink = "/legal/cookie-policy";
 function newCookieConsent(
     {
         functional,
-        analytics,
+        analytical,
         targeting,
     }: CookiePref,
 ): CookieConsent {
     return {
         necessary: true,
         functional: functional ?? false,
-        analytics: analytics ?? false,
+        analytical: analytical ?? false,
         targeting: targeting ?? false,
     };
 }
@@ -64,9 +64,9 @@ function AppCookieBanner() {
     };
 
     useEffect(() => {
-        const { functional, analytics, targeting } = loadCookieConsent(cookies);
+        const { functional, analytical, targeting } = loadCookieConsent(cookies);
 
-        setPref({ functional, analytics, targeting });
+        setPref({ functional, analytical, targeting });
 
         if (!cookies[consentCookieName] && !showingCustomizationPane) {
             dispatch(showCookieBanner());

--- a/src/app/legal/cookies/AppCookieCustomization.tsx
+++ b/src/app/legal/cookies/AppCookieCustomization.tsx
@@ -46,14 +46,14 @@ const getCookieUsage: (domain: MathSweDomain) => CustomizationCookieUsage =
 function newCookieConsent(
     {
         functional,
-        analytics,
+        analytical,
         targeting,
     }: CookiePref,
 ): CookieConsent {
     return {
         necessary: true,
         functional: functional ?? false,
-        analytics: analytics ?? false,
+        analytical: analytical ?? false,
         targeting: targeting ?? false,
     };
 }
@@ -83,9 +83,9 @@ function AppCookieBanner() {
         : getCookieUsage("mathswe.com");
 
     useEffect(() => {
-        const { functional, analytics, targeting } = loadCookieConsent(cookies);
+        const { functional, analytical, targeting } = loadCookieConsent(cookies);
 
-        setPref({ functional, analytics, targeting });
+        setPref({ functional, analytical, targeting });
     }, [ cookies, dispatch ]);
 
     useEffect(() => setDomainName(import.meta.env.VITE_DOMAIN_NAME ?? ""), []);

--- a/src/app/legal/cookies/cookie-consent.ts
+++ b/src/app/legal/cookies/cookie-consent.ts
@@ -1,0 +1,3 @@
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// This file is part of https://github.com/mathswe/mathswe.com
+

--- a/src/persistence/cookie-consent.ts
+++ b/src/persistence/cookie-consent.ts
@@ -9,14 +9,14 @@ export const consentCookieName = "cookie-consent";
 export interface CookieConsent {
     necessary: boolean;
     functional: boolean;
-    analytics: boolean;
+    analytical: boolean;
     targeting: boolean;
 }
 
 export const defConsent: CookieConsent = {
     necessary: true,
     functional: false,
-    analytics: false,
+    analytical: false,
     targeting: false,
 };
 
@@ -37,7 +37,7 @@ export function loadCookieConsent(cookies: Record<string, Record<string, string>
     return {
         necessary: true,
         functional: getBoolean("functional"),
-        analytics: getBoolean("analytics"),
+        analytical: getBoolean("analytical"),
         targeting: getBoolean("targeting"),
     };
 }

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -36,7 +36,7 @@ interface CookieActionProps {
 
 function CookieAction({ onSave, onCustomize, form }: CookieActionProps) {
     const [ functional, setFunctional ] = useState<boolean | undefined>();
-    const [ analytics, setAnalytics ] = useState<boolean | undefined>();
+    const [ analytical, setAnalytical ] = useState<boolean | undefined>();
     const [ targeting, setTargeting ] = useState<boolean | undefined>();
 
     const essentialOnly = () => { onSave(defPref); };
@@ -46,14 +46,14 @@ function CookieAction({ onSave, onCustomize, form }: CookieActionProps) {
     const saveSelection = () => {
         onSave({
             functional,
-            analytics,
+            analytical,
             targeting,
         });
     };
 
     useEffect(() => {
         setFunctional(form.functional);
-        setAnalytics(form.analytics);
+        setAnalytical(form.analytical);
         setTargeting(form.targeting);
     }, [ form ]);
 
@@ -86,9 +86,9 @@ function CookieAction({ onSave, onCustomize, form }: CookieActionProps) {
                     </div>
                     <div className="check-col">
                         <CheckAction
-                            name="analytics"
-                            state={ analytics }
-                            onChange={ setAnalytics }
+                            name="analytical"
+                            state={ analytical }
+                            onChange={ setAnalytical }
                         />
                         <CheckAction
                             name="targeting"

--- a/src/ui/legal/CookieCustomization.tsx
+++ b/src/ui/legal/CookieCustomization.tsx
@@ -236,7 +236,7 @@ function CookieAction(
     }: CookieActionProps,
 ) {
     const [ functional, setFunctional ] = useState<boolean | undefined>();
-    const [ analytics, setAnalytics ] = useState<boolean | undefined>();
+    const [ analytical, setAnalytical ] = useState<boolean | undefined>();
     const [ targeting, setTargeting ] = useState<boolean | undefined>();
 
     const essentialOnly = () => { onSave(defPref); };
@@ -246,14 +246,14 @@ function CookieAction(
     const saveSelection = () => {
         onSave({
             functional,
-            analytics,
+            analytical,
             targeting,
         });
     };
 
     useEffect(() => {
         setFunctional(form.functional);
-        setAnalytics(form.analytics);
+        setAnalytical(form.analytical);
         setTargeting(form.targeting);
     }, [ form ]);
 
@@ -293,9 +293,9 @@ function CookieAction(
                         cookies={ cookieUsage.analytical }
                     >
                         <SwitchAction
-                            name="analytics"
-                            state={ analytics }
-                            onChange={ setAnalytics }
+                            name="analytical"
+                            state={ analytical }
+                            onChange={ setAnalytical }
                         />
                     </CategoryItem>
 

--- a/src/ui/legal/cookie-pref.ts
+++ b/src/ui/legal/cookie-pref.ts
@@ -3,18 +3,18 @@
 
 export interface CookiePref {
     functional?: boolean;
-    analytics?: boolean;
+    analytical?: boolean;
     targeting?: boolean;
 }
 
 export const defPref: CookiePref = {
     functional: false,
-    analytics: false,
+    analytical: false,
     targeting: false,
 };
 
 export const acceptAllPref: CookiePref = {
     functional: true,
-    analytics: true,
+    analytical: true,
     targeting: true,
 };


### PR DESCRIPTION
It pairs with the last naming convention adopted by MathSwe Cookie Consent v0.2.0. See more: https://blog.mathsoftware.engineer/cookie-consent-v0-2-0---mathswe-legal-2024-04-09#request-and-response-integration.