### PR TITLE
Tune cookie consent id sizing in banner and fix public icon path in NotificationToast

### DIFF
--- a/src/app/legal/cookies/AppCookieBanner.tsx
+++ b/src/app/legal/cookies/AppCookieBanner.tsx
@@ -84,6 +84,7 @@ function AppCookieBanner() {
             onSave={ save }
             onClose={ closeBanner }
             onCustomize={ customize }
+            onExpandEffectiveConsent={ customize }
         />
     </>;
 }

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -40,7 +40,7 @@ function NotificationToast(
         <Toast show={ show } onClose={ onClose }>
             <Toast.Header>
                 <img
-                    src="/public/mathswe.svg"
+                    src="/mathswe.svg"
                     width="24px"
                     className="rounded me-2"
                     alt="Notification Icon"

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -18,9 +18,13 @@ function EffectiveConsent({ onSeeMore, consentId }: EffectiveConsentProps) {
     return consentId
         ? <>
             <div>
-                <strong>Effective Consent ID: </strong>
+                <strong>Effective Consent ID:</strong>&nbsp;
                 <span className="user-select-all">{ consentId }</span>
-                <Button variant="link" onClick={ onSeeMore }>
+                <Button
+                    variant="link"
+                    style={ { fontSize: "0.875rem" } }
+                    onClick={ onSeeMore }
+                >
                     See more
                 </Button>
             </div>

--- a/src/ui/legal/CookieBanner.tsx
+++ b/src/ui/legal/CookieBanner.tsx
@@ -18,10 +18,14 @@ function EffectiveConsent({ onSeeMore, consentId }: EffectiveConsentProps) {
     return consentId
         ? <>
             <div>
-                <strong>Effective Consent ID:</strong>&nbsp;
-                <span className="user-select-all">{ consentId }</span>
+                <strong>Effective Consent ID:</strong>
+                &nbsp;
+                <span className="d-inline-block p-1 user-select-all">
+                    { consentId }
+                </span>
                 <Button
                     variant="link"
+                    className="p-1"
                     style={ { fontSize: "0.875rem" } }
                     onClick={ onSeeMore }
                 >


### PR DESCRIPTION
It enhances the sizing of the cookie consent ID/"see more" detail in the Cookie Banner component. It fixes the public directory path to load the Notification Toast component icon in production.